### PR TITLE
Added stickers support, added limit/rating support to trending, and updated dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-6TO5 = ./node_modules/.bin/6to5
+BABEL = ./node_modules/.bin/babel
 
 all: node
 
@@ -7,7 +7,7 @@ node: lib
 	@mkdir -p ./node
 	@for path in lib/*.js; do \
 		file=`basename $$path`; \
-		$(6TO5) "lib/$$file" > "node/$$file"; \
+		$(BABEL) "lib/$$file" > "node/$$file"; \
 	done
 
 clean:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # apigiphy [![Build Status](https://travis-ci.org/Urucas/apigiphy.svg?branch=master)](https://travis-ci.org/Urucas/apigiphy)
 
-Giphy API made simple. 
+Giphy API made simple.
 
 *A node implementation of Giphy API requests. Check [GiphyApi](https://github.com/Giphy/GiphyAPI) for more info.*
 
@@ -33,15 +33,21 @@ Implemented methods
   q: q, // search query term or phrase
   limit: limit, // (optional) number of results to return, maximum 100. Default 25
   offset: offset, // (optional) results offset, defaults to 0
-  rating: rating // limit results to those rated (y,g, pg, pg-13 or r).
+  rating: rating // limit results to those rated (y,g, pg, pg-13 or r).,
+  stickers: false // (optional) set to true to search stickers api instead of gifs api. Default false
 }).then(success, error);
 
 .random({
   tag: tag, // the GIF tag to limit randomness by
   rating: rating // limit results to those rated (y,g, pg, pg-13 or r).
+  stickers: false, // (optional) set to true to search stickers api instead of gifs api. Default false
 }).then(success, error);
 
-.trending().then(success, error);
+.trending({
+    limit: limit, // (optional) number of results to return, maximum 100. Default 25
+    rating: rating, // limit results to those rated (y,g, pg, pg-13 or r).
+    stickers: false // (optional) set to true to search stickers api instead of gifs api. Default false
+}).then(success, error);
 ```
 
 **Run the example**

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,13 @@
 // es6 runtime requirements
-require('6to5/polyfill');
+require('babel/polyfill');
 import request from 'request';
 
 export default function apigiphy({
-  api_key 
+  api_key
 }){
   return {
     key: function() {
-      return api_key;  
+      return api_key;
     },
     search: function(params){
       let self = this;
@@ -21,10 +21,11 @@ export default function apigiphy({
           api_key : api_key,
           rating : self.rating(params.rating)
         };
-        let url = self.api_url("gifs/search");
+        let endpointPrefix = params.stickers ? "stickers" : "gifs";
+        let url = self.api_url(endpointPrefix + "/search");
         request.get({url:url, qs:qs}, function(error, response, body){
           if(error) reject(error);
-          if(response.statusCode != 200) reject(body);
+          if(response.statusCode !== 200) reject(body);
           resolve(JSON.parse(body));
         });
       });
@@ -39,37 +40,44 @@ export default function apigiphy({
           api_key: api_key,
           rating: self.rating(params.rating)
         };
-        let url = self.api_url("gifs/random");
+        let endpointPrefix = params.stickers ? "stickers" : "gifs";
+        let url = self.api_url(endpointPrefix + "/random");
         request.get({url:url, qs:qs}, function(error, response, body){
           if(error) reject(error);
-          if(response.statusCode != 200) reject(body);
+          if(response.statusCode !== 200) reject(body);
           resolve(JSON.parse(body));
         });
       });
     },
-    trending: function(){
+    trending: function(params){
+      if (!params) params = {};
       let self = this;
       return new Promise(function(resolve, reject){
-        let qs = {api_key:api_key};
-        let url = self.api_url("gifs/trending");
+        let qs = {
+            api_key: api_key,
+            limit: ~~params.limit > 0 ? params.limit : 25,
+            rating: self.rating(params.rating)
+        };
+        let endpointPrefix = params.stickers ? "stickers" : "gifs";
+        let url = self.api_url(endpointPrefix + "/trending");
         request.get({url:url, qs:qs}, function(error, response, body){
           if(error) reject(error);
-          if(response.statusCode != 200) reject(body);
+          if(response.statusCode !== 200) reject(body);
           resolve(JSON.parse(body));
         });
       });
     },
     rating: function(r) {
-      return ['y','g','pg','pg-13','r'].indexOf(r) != -1 ? r : "";
+      return ['y','g','pg','pg-13','r'].indexOf(r) !== -1 ? r : "";
     },
     api_url: function(request_url) {
       let api_endpoint = "http://api.giphy.com";
       let api_version  = "v1";
       return [
-        api_endpoint, 
-        api_version, 
+        api_endpoint,
+        api_version,
         request_url
       ].join('/');
     }
-  }
+  };
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Giphy API made simple",
   "main": "./node/index.js",
   "scripts": {
-    "test": "node_modules/mocha/bin/mocha tests/* --compilers js:6to5/register -t 15s --require mocha-clean"
+    "test": "node_modules/mocha/bin/mocha tests/* --compilers js:babel/register -t 15s --require mocha-clean"
   },
   "keywords": [
     "gif, giphy, api, images, animation"
@@ -20,12 +20,12 @@
   },
   "homepage": "https://github.com/Urucas/apigiphy",
   "dependencies": {
-    "6to5": "^3.6.5",
-    "request": "^2.53.0"
+    "babel": "~5.2.17",
+    "request": "^2.55.0"
   },
   "devDependencies": {
-    "6to5ify": "3.1.2",
-    "mocha": "2.1.0",
+    "babelify": "~6.0.2",
+    "mocha": "2.2.4",
     "mocha-clean": "^0.4.0"
   }
 }

--- a/tests/test.js
+++ b/tests/test.js
@@ -2,28 +2,28 @@ import apigiphy from '../lib/';
 import {api_key} from './config';
 
 describe("Apigiphy instance test", () => {
-  
+
   var giphy = apigiphy({api_key:api_key});
   it("Test rating method", (done) => {
     let rating = giphy.rating;
-    if(rating("y")!="y") 
+    if(rating("y")!="y")
       throw new Error("rating method fail while testing 'y' param");
-    
-    if(rating("g")!="g") 
+
+    if(rating("g")!="g")
       throw new Error("rating method fail while testing 'g' param");
-    
-    if(rating("pg")!="pg") 
+
+    if(rating("pg")!="pg")
       throw new Error("rating method fail while testing 'pg' param");
-    
-    if(rating("pg-13")!="pg-13") 
+
+    if(rating("pg-13")!="pg-13")
       throw new Error("rating method fail while testing 'pg-13' param");
-    
-    if(rating("r")!="r") 
+
+    if(rating("r")!="r")
       throw new Error("rating method fail while testing 'r' param");
-      
+
     done();
   });
-  
+
   it("Test api_url method", (done) => {
     let url = giphy.api_url("gifs/search");
     if(!url.match(/http:\/\/api.giphy.com\/v1\/gifs\/search/))
@@ -46,7 +46,7 @@ describe("Apigiphy instance test", () => {
         else throw new Error(response.meta.msg);
       })
     }catch(e){
-      throw new Error(e.getMessage);  
+      throw new Error(e.getMessage);
     }
   });
 
@@ -57,7 +57,7 @@ describe("Apigiphy instance test", () => {
         else throw new Error(response.meta.msg);
       })
     }catch(e){
-      throw new Error(e.getMessage);  
+      throw new Error(e.getMessage);
     }
   });
 
@@ -68,7 +68,18 @@ describe("Apigiphy instance test", () => {
         else throw new Error(response.meta.msg);
       })
     }catch(e){
-      throw new Error(e.getMessage);  
+      throw new Error(e.getMessage);
+    }
+  });
+
+  it("Test stickers flag", (done) => {
+    try {
+      giphy.search({q:"test", stickers: true}).then(function(response){
+        if(response.meta.status == 200) done();
+        else throw new Error(response.meta.msg);
+      })
+    }catch(e){
+      throw new Error(e.getMessage);
     }
   });
 


### PR DESCRIPTION
Added `stickers` boolean to endpoints. This allows querying the Giphy stickers API as well as their standard gif API.

Added `limit` and `rating` parameters to `trending` endpoint.

Replaced `6to5` (deprecated) with `babel`.
Replaced `6to5ify` (deprecated) with `babelify`.
Updated `mocha` and `request` dependencies.